### PR TITLE
fix: restore versionCode and versionName in Config

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "it.ministerodellasalute.verificaC19"
         minSdkVersion Config.minSdk
         targetSdkVersion Config.targetSdk
-        versionCode 1
-        versionName "0.0.0"
+        versionCode Config.versionCode
+        versionName Config.versionName
         testInstrumentationRunner Config.androidTestInstrumentation
     }
 


### PR DESCRIPTION
versionCode and versionName are now retrieved from AppConfig
versionName set to 1.0.0 to avoid forced update