### PR TITLE
feat: implemented verification of a QR Code coming from a broadcast intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,12 @@
             android:name=".ui.main.MainActivity"
             android:configChanges="orientation|keyboardHidden"
             android:screenOrientation="portrait" />
+
+        <activity
+            android:name=".ui.main.VerificationActivity"
+            android:configChanges="orientation|keyboardHidden"
+            android:screenOrientation="portrait" />
+
         <activity
             android:name=".ui.FirstActivity"
             android:configChanges="orientation|keyboardHidden"

--- a/app/src/main/java/it/ministerodellasalute/verificaC19/ui/BarcodeBroadcastReceiver.kt
+++ b/app/src/main/java/it/ministerodellasalute/verificaC19/ui/BarcodeBroadcastReceiver.kt
@@ -1,0 +1,47 @@
+/*
+ *  ---license-start
+ *  eu-digital-green-certificates / dgca-verifier-app-android
+ *  ---
+ *  Copyright (C) 2021 T-Systems International GmbH and all other contributors
+ *  ---
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  ---license-end
+ *
+ */
+
+package it.ministerodellasalute.verificaC19.ui
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import it.ministerodellasalute.verificaC19.ui.main.VerificationActivity
+
+class BarcodeBroadcastReceiver : BroadcastReceiver() {
+    companion object {
+        const val ACTION = "it.ministerodellasalute.verificaC19.decode_action"
+        const val CATEGORY = "it.ministerodellasalute.verificaC19.decode_category"
+        const val BARCODE_STRING = "it.ministerodellasalute.verificaC19.barcode_string"
+    }
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent?.action.equals(ACTION)) {
+            val barcodeString: String? = intent?.extras?.getString(BARCODE_STRING)
+            if (barcodeString != null && barcodeString.isNotEmpty()) {
+                val verificationIntent = Intent(context, VerificationActivity::class.java)
+                verificationIntent.putExtra("qrCodeText", barcodeString)
+                verificationIntent.putExtra("finishOnClose", true)
+                context?.startActivity(verificationIntent)
+            }
+        }
+    }
+}

--- a/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/VerificationActivity.kt
+++ b/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/VerificationActivity.kt
@@ -1,0 +1,50 @@
+/*
+ *  ---license-start
+ *  eu-digital-green-certificates / dgca-verifier-app-android
+ *  ---
+ *  Copyright (C) 2021 T-Systems International GmbH and all other contributors
+ *  ---
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  ---license-end
+ *
+ */
+
+package it.ministerodellasalute.verificaC19.ui.main
+
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import it.ministerodellasalute.verificaC19.BuildConfig
+import it.ministerodellasalute.verificaC19.R
+
+@AndroidEntryPoint
+class VerificationActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (!BuildConfig.DEBUG) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
+        setContentView(R.layout.activity_verification)
+
+        val destinationArgs = Bundle()
+        destinationArgs.putString("qrCodeText", intent.getStringExtra("qrCodeText"))
+        destinationArgs.putBoolean("finishOnClose", intent.getBooleanExtra("finishOnClose", false))
+        findNavController(R.id.nav_host_fragment_verification_only).setGraph(
+            R.navigation.nav_graph_verification_only, destinationArgs)
+    }
+}

--- a/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/verification/VerificationFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/verification/VerificationFragment.kt
@@ -173,7 +173,13 @@ class VerificationFragment : Fragment(), View.OnClickListener {
 
     override fun onClick(v: View?) {
         when (v?.id) {
-            R.id.close_button -> findNavController().popBackStack()
+            R.id.close_button -> {
+                if (args.finishOnClose) {
+                    requireActivity().finish()
+                } else {
+                    findNavController().popBackStack()
+                }
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_verification.xml
+++ b/app/src/main/res/layout/activity_verification.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  license-start
+  ~  eu-digital-green-certificates / dgca-verifier-app-android
+  ~
+  ~  Copyright (C) 2021 T-Systems International GmbH and all other contributors
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~  license-end
+  ~
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <fragment
+        android:id="@+id/nav_host_fragment_verification_only"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph_verification_only.xml
+++ b/app/src/main/res/navigation/nav_graph_verification_only.xml
@@ -17,31 +17,16 @@
   ~  limitations under the License.
   ~  license-end
   ~
-  ~  Created by Mykhailo Nester on 4/23/21 9:53 AM
   -->
 
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/nav_graph"
-    app:startDestination="@id/codeReaderFragment">
+    android:id="@+id/nav_graph_verification_only"
+    app:startDestination="@id/verificationOnlyFragment">
 
     <fragment
-        android:id="@+id/codeReaderFragment"
-        android:name="it.ministerodellasalute.verificaC19.ui.main.codeReader.CodeReaderFragment"
-        android:label="CodeReader"
-        tools:layout="@layout/fragment_code_reader">
-
-        <action
-            android:id="@+id/action_codeReaderFragment_to_verificationFragment"
-            app:destination="@id/verificationFragment"
-            app:enterAnim="@anim/slide_in_right"
-            app:exitAnim="@anim/slide_out_left" />
-
-    </fragment>
-
-    <fragment
-        android:id="@+id/verificationFragment"
+        android:id="@+id/verificationOnlyFragment"
         android:name="it.ministerodellasalute.verificaC19.ui.main.verification.VerificationFragment"
         android:label="VerificationFragment"
         tools:layout="@layout/fragment_verification">


### PR DESCRIPTION
This PR adds a way to receive a decoded QR Code from a broadcast intent and use it for verification.
A broadcast receiver is registered in the FirstActivity in order to manage this kind of intent. The intent filter for this receiver takes a predefined action and category. Upon receiving the intent with the specified action and category, the barcode string is retrieved as an extra of the received intent. A new activity (VerificationActivity) and nav graph have been added to allow launching the verification fragment alone, passing it the barcode string.
I believe this change can be helpful to verify codes without using the camera itself, for example taking advantage of professional scanners that can send an intent with the barcode content.

TEST:
In order to verify this, open the VerificaC19 app and stay in the FirstActivity screen.
From an ADB shell, you can send a broadcast with the command:
am broadcast -a it.ministerodellasalute.verificaC19.decode_action -c it.ministerodellasalute.verificaC19.decode_category -e it.ministerodellasalute.verificaC19.barcode_string BARCODE_STRING
Substitute BARCODE_STRING with the string you need to test, being careful about eventual characters to escape.

NOTE:
I think as further improvement, the strings used for action, category and barcode string extra could be customized. I've tried to use generic strings in order to avoid sticking with a specific implementation. However, if this kind of implementation could be helpful for integration with professional scanners, at least the barcode string extra needs to be modified because some devices have it hardcoded.