### PR TITLE
Resolve: https://github.com/ministero-salute/it-dgc-verificaC19-android/issues/68

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,7 +46,12 @@
         <activity
             android:name=".ui.main.MainActivity"
             android:configChanges="orientation|keyboardHidden"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="portrait" >
+            <intent-filter>
+                <action android:name="it.ministerodellasalute.verificaC19.checkqr"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
         <activity
             android:name=".ui.FirstActivity"
             android:configChanges="orientation|keyboardHidden"

--- a/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/verification/VerificationFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/verification/VerificationFragment.kt
@@ -93,6 +93,7 @@ class VerificationFragment : Fragment(), View.OnClickListener {
                 Intent(CHECK_VALIDITY_INTENT).also { result ->
                     result.putExtra("givenName", certificateModel.person?.givenName)
                     result.putExtra("familyName", certificateModel.person?.familyName)
+                    result.putExtra("dateOfBirth", certificateModel.dateOfBirth)
                     activity.setResult(
                         if (certificateModel.isValid) {
                             Activity.RESULT_OK

--- a/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/verification/VerificationFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/verification/VerificationFragment.kt
@@ -91,6 +91,8 @@ class VerificationFragment : Fragment(), View.OnClickListener {
         activity?.let { activity ->
             if (activity.intent.action == CHECK_VALIDITY_INTENT) {
                 Intent(CHECK_VALIDITY_INTENT).also { result ->
+                    result.putExtra("givenName", certificateModel.person?.givenName)
+                    result.putExtra("familyName", certificateModel.person?.familyName)
                     activity.setResult(
                         if (certificateModel.isValid) {
                             Activity.RESULT_OK

--- a/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/verification/VerificationFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/verification/VerificationFragment.kt
@@ -20,6 +20,8 @@
 
 package it.ministerodellasalute.verificaC19.ui.main.verification
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -43,6 +45,10 @@ import java.util.*
 @ExperimentalUnsignedTypes
 @AndroidEntryPoint
 class VerificationFragment : Fragment(), View.OnClickListener {
+    companion object {
+        private const val CHECK_VALIDITY_INTENT = "it.ministerodellasalute.verificaC19.checkqr"
+        private const val CHECK_VALIDITY_INTENT_RESULT_KO = 1234
+    }
 
     private val args by navArgs<VerificationFragmentArgs>()
     private val viewModel by viewModels<VerificationViewModel>()
@@ -72,12 +78,31 @@ class VerificationFragment : Fragment(), View.OnClickListener {
                 certificateModel = it
                 setPersonData(it.person, it.dateOfBirth)
                 setupCertStatusView(it)
+                handleCheckQrIntent(it)
             }
         }
         viewModel.inProgress.observe(viewLifecycleOwner) {
             binding.progressBar.isVisible = it
         }
         viewModel.init(args.qrCodeText)
+    }
+
+    private fun handleCheckQrIntent(certificateModel: CertificateModel) {
+        activity?.let { activity ->
+            if (activity.intent.action == CHECK_VALIDITY_INTENT) {
+                Intent(CHECK_VALIDITY_INTENT).also { result ->
+                    activity.setResult(
+                        if (certificateModel.isValid) {
+                            Activity.RESULT_OK
+                        } else {
+                            CHECK_VALIDITY_INTENT_RESULT_KO
+                        },
+                        result
+                    )
+                }
+                activity.finish()
+            }
+        }
     }
 
     private fun setupCertStatusView(cert: CertificateModel) {


### PR DESCRIPTION
Resolve https://github.com/ministero-salute/it-dgc-verificaC19-android/issues/68 by adding an intent filter that **3rd parties app** could use to **ask** verificaC19 to scan a green pass and obtain the essential **scan results** (_validity_ — valid, invalid —, _date of birth_, _family_ and _given_ name).

Example usage:

```kotlin
private fun startC19() {
    startActivityForResult(Intent(
        "it.ministerodellasalute.verificaC19.checkqr"),
        8888
    )
}

override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
    super.onActivityResult(requestCode, resultCode, data)
    if (requestCode == 8888) {
        Log.d("TAG","QR code is valid: ${resultCode == Activity.RESULT_OK}")
        if (data?.hasExtra("familyName") == true) {
            Log.d("TAG", "QR code family name: ${data.extras?.get("familyName") ?: ""}")
        }
        if (data?.hasExtra("givenName") == true) {
            Log.d("TAG","QR code given name: ${data.extras?.get("givenName") ?: ""}")
        }
        if (data?.hasExtra("dateOfBirth") == true) {
            Log.d("TAG","QR code dob: ${data.extras?.get("dateOfBirth") ?: ""}")
        }
    }
}
```