### PR TITLE
Risolve #68 tramite Intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,12 @@
         <activity
             android:name=".ui.main.MainActivity"
             android:configChanges="orientation|keyboardHidden"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="portrait" >
+            <intent-filter>
+                <action android:name="it.ministerodellasalute.verificaC19.checkqr" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
         <activity
             android:name=".ui.FirstActivity"
             android:configChanges="orientation|keyboardHidden"

--- a/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/verification/VerificationFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/verificaC19/ui/main/verification/VerificationFragment.kt
@@ -45,10 +45,7 @@ import it.ministerodellasalute.verificaC19.ui.compounds.QuestionCompound
 import it.ministerodellasalute.verificaC19.ui.main.MainActivity
 import it.ministerodellasalute.verificaC19sdk.VerificaMinSDKVersionException
 import it.ministerodellasalute.verificaC19sdk.VerificaMinVersionException
-import it.ministerodellasalute.verificaC19sdk.model.CertificateSimple
-import it.ministerodellasalute.verificaC19sdk.model.CertificateStatus
-import it.ministerodellasalute.verificaC19sdk.model.SimplePersonModel
-import it.ministerodellasalute.verificaC19sdk.model.VerificationViewModel
+import it.ministerodellasalute.verificaC19sdk.model.*
 import it.ministerodellasalute.verificaC19sdk.util.FORMATTED_BIRTHDAY_DATE
 import it.ministerodellasalute.verificaC19sdk.util.FORMATTED_VALIDATION_DATE
 import it.ministerodellasalute.verificaC19sdk.util.TimeUtility.parseFromTo
@@ -58,6 +55,14 @@ import it.ministerodellasalute.verificaC19sdk.util.YEAR_MONTH_DAY
 @ExperimentalUnsignedTypes
 @AndroidEntryPoint
 class VerificationFragment : Fragment(), View.OnClickListener {
+    companion object {
+        private const val CHECK_VALIDITY_INTENT = "it.ministerodellasalute.verificaC19.checkqr"
+        private const val CHECK_VALIDITY_INTENT_RESULT_NOT_VALID = 0
+        private const val CHECK_VALIDITY_INTENT_RESULT_NOT_VALID_YET = 1
+        private const val CHECK_VALIDITY_INTENT_RESULT_VALID = 2
+        private const val CHECK_VALIDITY_INTENT_RESULT_PARTIALLY_VALID = 3
+        private const val CHECK_VALIDITY_INTENT_RESULT_NOT_EU_DCC = 4
+    }
 
     private val args by navArgs<VerificationFragmentArgs>()
     private val viewModel by viewModels<VerificationViewModel>()
@@ -89,6 +94,7 @@ class VerificationFragment : Fragment(), View.OnClickListener {
                         activity?.onBackPressed()
                     }, 5000)
                 }
+                handleCheckQrIntent(it)
             }
         }
         viewModel.inProgress.observe(viewLifecycleOwner) {
@@ -234,6 +240,23 @@ class VerificationFragment : Fragment(), View.OnClickListener {
         val dialog = builder.create()
         dialog.setCancelable(true)
         dialog.show()
+    }
+
+    private fun handleCheckQrIntent(certificateSimple: CertificateSimple) {
+        activity?.let { activity ->
+            if (activity.intent.action == CHECK_VALIDITY_INTENT) {
+                Intent(CHECK_VALIDITY_INTENT).also { result ->
+                    result.putExtra("givenName", certificateSimple.person?.givenName)
+                    result.putExtra("familyName", certificateSimple.person?.familyName)
+                    result.putExtra("dateOfBirth", certificateSimple.dateOfBirth)
+                    result.putExtra("resultStr",  certificateSimple.certificateStatus?.name);
+                    result.putExtra("result", certificateSimple.certificateStatus?.ordinal);
+
+                    activity.setResult(certificateSimple.certificateStatus!!.ordinal , result );
+                }
+                activity.finish()
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Soluzione con Intent filter per poter verificare il GreenPass tramite altra app.

Risolve il bug di @shadowsheep1 nel ResultCode.

Il risultato è dato dal valore ordinale del CertificateStatus.
Inoltre il risultato contiene Nome, Cognome e data di nascita.

La app chiamante è simile a questa:

public class MainActivity extends AppCompatActivity {
    private final String CHECK_VALIDITY_INTENT = "it.ministerodellasalute.verificaC19.checkqr"
    private final Integer CHECK_VALIDITY_INTENT_RESULT_NOT_VALID = 0;
    private final Integer CHECK_VALIDITY_INTENT_RESULT_NOT_VALID_YET = 1;
    private final Integer CHECK_VALIDITY_INTENT_RESULT_VALID = 2;
    private final Integer CHECK_VALIDITY_INTENT_RESULT_PARTIALLY_VALID = 3;
    private final Integer CHECK_VALIDITY_INTENT_RESULT_NOT_EU_DCC = 4;

    @Override
    protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        setContentView(R.layout.activity_main);
        Intent i = new Intent(CHECK_VALIDITY_INTENT);
        startActivityForResult(i, 0);
    }

    @Override
    protected void onActivityResult(int requestCode, int resultCode, Intent databack) {
        if (resultCode == CHECK_VALIDITY_INTENT_RESULT_VALID || resultCode == CHECK_VALIDITY_INTENT_RESULT_PARTIALLY_VALID) {
            new SendCanData(true).execute();
        } else {
            new SendCanData(false).execute();
        }

        String givenName = (String) databack.getExtras().get("givenName");
        String familyName = (String) databack.getExtras().get("familyName");
        String resultStr = (String) databack.getExtras().get("resultStr");
        Toast.makeText(this, resultStr, Toast.LENGTH_SHORT).show();

        Intent i = new Intent(CHECK_VALIDITY_INTENT);
        startActivityForResult(i, 0);
    }

}