### PR TITLE
Fix : CI Build - Runtime fixes for Android 12

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -25,7 +25,7 @@ jobs:
         path: dgca-verifier-app-android
     - uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
         distribution: adopt
     - uses: android-actions/setup-android@v2
     - uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         path: dgca-verifier-app-android
     - uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
         distribution: adopt
     - uses: android-actions/setup-android@v2
     - uses: actions/cache@v2

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
         <activity
             android:name=".ui.SplashScreenActivity"
             android:configChanges="orientation|keyboardHidden"
+            android:exported="true"
             android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -61,10 +62,15 @@
             android:screenOrientation="portrait" />
 
         <provider
-            android:name="androidx.work.impl.WorkManagerInitializer"
-            android:authorities="${applicationId}.workmanager-init"
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
-            tools:node="remove" />
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
     </application>
 
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,11 @@ allprojects {
         google()
         jcenter()
     }
+    project.configurations.all {
+        resolutionStrategy {
+            force Deps.androidx_worker_ktx
+        }
+    }
 }
 
 task clean(type: Delete) {

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -50,7 +50,7 @@ object Versions {
     const val androidx_hilt_viewmodel = "1.0.0-alpha02"
     const val androidx_hilt_work = work_hilt
     const val androidx_hilt_compiler = work_hilt
-    const val androidx_worker_ktx = "2.5.0"
+    const val androidx_worker_ktx = "2.7.1"
     const val hilt_version = "2.33-beta"
 
     // QR


### PR DESCRIPTION

* Fix : CI Build - Runtime fixes for Android 12

compileSdk / targetSdk upgrade from API level 30 (Android 11/R) to 31 (Android 12/R) requires additional fixes in order to avoid CI failures on build & LoadKeysWorker crash while running the app on Android 12+ devices.

**This PR fixes CI Build & Runtime issues with PR** #236 = it should be merged into refactor/update-dependencies branch in order to update PR 236 & remove the issues before merging it into develop branch.

---------------------

Fix Details : 
- JDK CI java-version upgrade from 1.8 to 11 in order to avoid java.lang.AssertionError when building with compileSdk/targetSdk 31 (_details [here](https://github.com/ministero-salute/it-dgc-verificaC19-android/pull/236#issuecomment-1010305713)_)

- androidx.work:work-runtime-ktx dependency version upgrade from 2.5.0 to 2.7.1 + top-level project dependency override (in order to keep alignment between app & other projects). It avoids LoadKeysWorker crash when starting the app on devices with Android 12/S (_details [here](https://github.com/ministero-salute/it-dgc-verificac19-sdk-android/issues/67#issuecomment-979440076)_)

- Using androidx.startup to initialize WorkManager (required since work-runtime-ktx:2.6.0)

- Added android:exported for .ui.SplashScreenActivity in AndroidManifest (_android:exported declaration is required by targetSdk 31 for all activities with intent-filters_)

---------------------


