### PR TITLE
fix: handle no camera permissions

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/verificaC19/ui/FirstActivity.kt
+++ b/app/src/main/java/it/ministerodellasalute/verificaC19/ui/FirstActivity.kt
@@ -27,6 +27,7 @@ import android.content.pm.PackageManager
 import android.graphics.Typeface
 import android.net.Uri
 import android.os.Bundle
+import android.provider.Settings
 import android.text.Html
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
@@ -78,9 +79,7 @@ class FirstActivity : AppCompatActivity(), View.OnClickListener,
 
     private val requestPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
-            if (isGranted) {
-                openQrCodeReader()
-            }
+            if (isGranted) openQrCodeReader() else noPermissionsGrantedCamera()
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -406,7 +405,7 @@ class FirstActivity : AppCompatActivity(), View.OnClickListener,
         startActivity(intent)
     }
 
-    private fun openSettings() {
+    private fun openSettingsActivity() {
         val intent = Intent(this, SettingsActivity::class.java)
         startActivity(intent)
     }
@@ -439,7 +438,7 @@ class FirstActivity : AppCompatActivity(), View.OnClickListener,
                 }
                 checkCameraPermission()
             }
-            R.id.settings -> openSettings()
+            R.id.settings -> openSettingsActivity()
             R.id.scan_mode_button -> {
                 viewModel.getRuleSet()?.run {
                     ScanModeDialogFragment(viewModel.getRuleSet()!!).show(supportFragmentManager, "SCAN_MODE_DIALOG_FRAGMENT")
@@ -519,6 +518,30 @@ class FirstActivity : AppCompatActivity(), View.OnClickListener,
                     Uri.parse("https://play.google.com/store/apps/details?id=$packageName")
                 )
             )
+        }
+    }
+
+    private fun noPermissionsGrantedCamera() {
+        val builder = AlertDialog.Builder(this)
+        val dialog: AlertDialog?
+        builder.setTitle(
+            getString(R.string.no_permissions_granted_camera_title)
+        )
+        builder.setMessage(getString(R.string.no_permissions_granted_camera_message))
+        builder.setPositiveButton(getString(R.string.open_settings)) { _, _ -> openSettings() }
+        builder.setNegativeButton(getString(R.string.not_now)) { _, _ -> }
+        dialog = builder.create()
+        dialog.show()
+    }
+
+    private fun openSettings() {
+        try {
+            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+            val uri = Uri.fromParts("package", packageName, null)
+            intent.data = uri
+            startActivity(intent)
+        } catch (e: Exception) {
+            Log.i("openSettings", e.toString())
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -166,4 +166,9 @@
     <string name="userDataDoesNotMatch">Dati anagrafici non congruenti</string>
     <string name="scan_mode_fragment_title">Modalità di verifica della <b>Certificazione</b></string>
     <string name="confirm_scan_mode_button">Conferma</string>
+
+    <string name="no_permissions_granted_camera_title">Permessi fotocamera necessari</string>
+    <string name="no_permissions_granted_camera_message">VerificaC19 necessita di accedere alla fotocamera del telefono. Apri le impostazioni per autorizzare l\'app.</string>
+    <string name="not_now">Non ora</string>
+    <string name="open_settings">Apri impostazioni</string>
 </resources>


### PR DESCRIPTION
This commit handles the situation when a user clicks on the scan button after denying the camera permissions to the app.
Previously, nothing was shown to the user when `isGranted` is false due to the above case: now, an alert dialog will ask the user to open the settings to grant the required permissions to VerificaC19.