### PR TITLE
Fix : Force Deps per OK decoder in desugaring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ allprojects {
     project.configurations.all {
         resolutionStrategy {
             force Deps.androidx_worker_ktx
+            force Deps.jackson_cbor
+            force Deps.kotlin_stdlib
+            force Deps.kotlin_reflect
+            force Deps.desugar_jdk_libs
         }
     }
 }


### PR DESCRIPTION
cc @astagi / @it-eucert-team / @nicola-95 

---------------

- **Fix : Force Deps per OK decoder in desugaring**

---------------

## **Problema Riscontrato**
Utilizzando whitelabel-app release 1.3.3 + DGC-SDK 1.1.1 + DGCA core (main) in condizioni desugaring API <26 (_quindi con API24 - Nougat 7.0 e API25 - Nougat 7.1_), si riscontrano KO cborservice in runtime.

In tali situazioni il decoder/core restituisce null, per cui di conseguenza il validator di DGC-SDK restituisce `CertificateStatus.NOT_EU_DCC` . 

\
Tale KO decoder/cborservice risulta dovuto ad un'incompatibilità tra alcune dependency definite per il modulo DGCA core decoder (_ved. [commit `4039792` - Nov 17, 2022 - in relativa main branch](https://github.com/eu-digital-green-certificates/dgca-app-core-android/commit/4039792a01a19388bafa1374a4318849a03e05b2)_) e le impostazioni di conversione delle desugaring libs versione 1.1.5 .

--------------------

## **Fix proposto**
Dato che l'allineamento di whitelabel-app + DGC-SDK richiederebbe comunque modifiche sia delle versioni AGP/Gradle (_desugaring libs 2.0.0 richiedono AGP 7.4.0_) che di dipendenze e funzioni, propongo un fix in ottica "keep it simple" per il mantenimento di desugaring con minSdk <26. 

Applica infatti un semplice override/revert di determinate dipendenze del modulo DGCA - _incompatibili con condizioni desugaring libs 1.1.5_ - allineando le versioni con quelle definite prima di tale commit & esenti da problemi per desugaring con whitelabel-app 1.3.3 + DGC-SDK 1.1.1 : 

| Dependency in DGCA core                                  | EU-DGC version | forced version |
|----------------------------------------------------------|----------------|----------------|
| com.fasterxml.jackson.dataformat:jackson-dataformat-cbor | 2.14.0         | 2.12.3         |
| org.jetbrains.kotlin:kotlin-stdlib                       | 1.6.21         | 1.4.32         |
| org.jetbrains.kotlin:kotlin-reflect                      | 1.6.21         | 1.4.32         |
| com.android.tools:desugar_jdk_libs                       | 2.0.0          | 1.1.5          |

\
OK con API 24/25 e non ho riscontrato variazioni nei runtime-test effettuati finora con API 26->33. Effettuerò comunque per scrupolo ulteriori test con dispositivi fisici su API 32 e 33.